### PR TITLE
Multiple uploads to Test PyPI

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,7 +3,7 @@ name: Build Wheels and upload to PyPI
 on:
   pull_request:
     branches:
-      - "releases/v[0-9].[0-9]+.[0-9]+"
+      - "releases/**"
     types: [labeled, opened, synchronize, reopened]
   release:
     types: [published]

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "releases/**"
-    types: ["synchronize"]
+    types: [labeled, opened, synchronize, reopened]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,7 +3,7 @@ name: Build Wheels and upload to PyPI
 on:
   pull_request:
     branches:
-      - "releases/**"
+      - "releases/v[0-9].[0-9]+.[0-9]+"
     types: [labeled, opened, synchronize, reopened]
   release:
     types: [published]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
           python-version: ${{matrix.python-version}}
           cache: "poetry"
 
+      - name: Set up Poetry Dynamic Versioning
+        run: |
+          poetry self add "poetry-dynamic-versioning[plugin]"
+
       - name: Linting, Typechecking and Formatting
         uses: pre-commit/action@v3.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alpineer"
-version = "0.1.4"
+version = "0.0.0"
 description = "Toolbox for Multiplexed Imaging. Contains scripts and little tools which are used throughout ark-analysis, mibi-bin-tools, and toffy."
 authors = [
     "Noah Frey Greenwald <nfgreen@stanford.edu>",
@@ -17,9 +17,23 @@ readme = "README.md"
 packages = [{ include = 'alpineer', from = 'src' }]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
 
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+format-jinja = """
+    {%- if distance == 0 -%}
+        {{ serialize_pep440(base, stage, revision) }}
+    {%- elif revision is not none -%}
+        {{ serialize_pep440(base, stage, revision + 1, dev=distance, metadata=[commit]) }}
+    {%- else -%}
+        {{ serialize_pep440(bump_version(base), stage, revision, dev=distance, metadata=[commit]) }}
+    {%- endif -%}
+"""
+bump = false
+style = "pep440"
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -38,7 +52,7 @@ optional = true
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"
-coveralls = {version = "^3.3.1", extras = ["toml"]}
+coveralls = { version = "^3.3.1", extras = ["toml"] }
 pytest-cases = "^3.6.13"
 pytest-order = "^1.0.1"
 pytest-cov = "^4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ enable = true
 vcs = "git"
 bump = true
 style = "pep440"
-# format = "v{base}+{distance}.{commit}"
+metadata = false
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,17 +23,8 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
-format-jinja = """
-    {%- if distance == 0 -%}
-        {{ serialize_pep440(base, stage, revision) }}
-    {%- elif revision is not none -%}
-        {{ serialize_pep440(base, stage, revision + 1, dev=distance, metadata=[commit]) }}
-    {%- else -%}
-        {{ serialize_pep440(bump_version(base), stage, revision, dev=distance, metadata=[commit]) }}
-    {%- endif -%}
-"""
-bump = false
-style = "pep440"
+bump = true
+style = "semver"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ build-backend = "poetry_dynamic_versioning.backend"
 enable = true
 vcs = "git"
 bump = true
-style = "semver"
+style = "pep440"
+# format = "v{base}+{distance}.{commit}"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #21. On a release branch, allows us to build Pure Python 3 Wheels for each commit, and be able to push them to Test PyPI. 

**How did you implement your changes**

This was accomplished with the [poetry dynamic versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) plugin. Added `format` section under `tool.poetry-dynamic-versioning` in the `pyproject.toml` file. When on a release branch such as this one, wheels will be built for the *next* patch version. This ensures that there will not be duplicate uploads to Test PyPI when developing in a `releases/vX.Y.Z` branch.

For example, in this branch, we have a wheel named `alpineer-0.1.5.dev5-py3-none-any.whl`, where:
- `dev` stands for development candidate, and `5` is the distance, or the number of commits ahead of version `0.1.4`.

For new releases, created from [the releases page](https://github.com/angelolab/alpineer/releases):
1. Select the latest Draft Release
2. Change the tag if needed to an appropriate version
3. Publish the release
   1. A tag supersedes any version currently in the `pyproject.toml`, and the newly built wheels will be named something akin to `alpineer-0.1.5-py3-none-any.whl`.


Here is a [job which uploaded to testpypi successfully](https://github.com/angelolab/alpineer/actions/runs/4166428409)
**Remaining issues**

N/A