### PR TITLE
Get Tiled FOV names regex fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.lcov
 *.cover
 *.py,cover
 .hypothesis/

--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -379,7 +379,7 @@ def get_tiled_fov_names(fov_list, return_dims=False):
 
     Args:
         fov_list (list):
-            list of fov names
+            list of fov names with are suffixed with RnCm, where n and m are any integer.
         return_dims (bool):
             whether to also return row and col dimensions
     Returns:
@@ -390,12 +390,14 @@ def get_tiled_fov_names(fov_list, return_dims=False):
 
     # check for run name prefix
     prefix, fov_names = check_fov_name_prefix(fov_list)
+    search_term: re.Pattern = re.compile(r"(R\+?\d+)(C\+?\d+)")
 
     # get tiled image dimensions
     for fov in fov_names:
-        fov_digits = re.findall(r"\d+", fov)
-        rows.append(int(fov_digits[0]))
-        cols.append(int(fov_digits[1]))
+        R,C = re.search(search_term, fov).group(1,2)
+        rows.append(int(R[1:]))
+        cols.append(int(C[1:]))
+
     row_num, col_num = max(rows), max(cols)
 
     # fill list of expected fov names

--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -394,7 +394,7 @@ def get_tiled_fov_names(fov_list, return_dims=False):
 
     # get tiled image dimensions
     for fov in fov_names:
-        R,C = re.search(search_term, fov).group(1,2)
+        R, C = re.search(search_term, fov).group(1, 2)
         rows.append(int(R[1:]))
         cols.append(int(C[1:]))
 

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -3,6 +3,7 @@ import pathlib
 import shutil
 import tempfile
 from typing import Any, Iterator, List, OrderedDict, Tuple
+import natsort as ns
 
 import numpy as np
 import pytest
@@ -370,7 +371,7 @@ def test_get_tiled_fov_names():
     # check no missing fovs, should return a list with all fovs for a 3x4 tiling
     fov_names = ["R1C1", "R1C2", "R2C1", "R2C2"]
 
-    expected_fovs = load_utils.get_tiled_fov_names(fov_names)
+    expected_fovs = load_utils.get_tiled_fov_names(fov_names, return_dims=False)
     assert expected_fovs == ["R1C1", "R1C2", "R2C1", "R2C2"]
 
     # check no missing fovs and run name attached, should return a list for 1x3 tiling
@@ -381,7 +382,7 @@ def test_get_tiled_fov_names():
     assert (rows, cols) == (1, 3)
 
     # check missing fovs, should return a list with all fovs for a 3x4 tiling
-    fov_names = ["R1C1", "R1C2", "R2C1", "R2C4", "RC3C1"]
+    fov_names = ["R1C1", "R1C2", "R2C1", "R2C4", "R3C1"]
 
     expected_fovs, rows, cols = load_utils.get_tiled_fov_names(fov_names, return_dims=True)
     assert expected_fovs == [
@@ -406,6 +407,14 @@ def test_get_tiled_fov_names():
     expected_fovs, rows, cols = load_utils.get_tiled_fov_names(fov_names, return_dims=True)
     assert expected_fovs == ["Run_10_R1C1", "R1C2", "Run_20_R1C3"]
     assert (rows, cols) == (1, 3)
+    
+    # Check that indicies larger than 9 are handled appropriately.
+    fov_names = ["R1C1", "R10C1", "R2C12"]
+    expected_fovs, rows, cols = load_utils.get_tiled_fov_names(fov_names, return_dims=True)
+    
+    assert ns.natsorted([f"R{n}C{m}" for n in range(1,11) for m in range(1,13)]) == expected_fovs
+    
+    assert (rows, cols) == (10, 12)
 
 
 @pytest.mark.parametrize("single_dir, img_sub_folder", [(False, "TIFs"), (True, "")])

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -3,8 +3,8 @@ import pathlib
 import shutil
 import tempfile
 from typing import Any, Iterator, List, OrderedDict, Tuple
-import natsort as ns
 
+import natsort as ns
 import numpy as np
 import pytest
 import xarray as xr
@@ -407,13 +407,13 @@ def test_get_tiled_fov_names():
     expected_fovs, rows, cols = load_utils.get_tiled_fov_names(fov_names, return_dims=True)
     assert expected_fovs == ["Run_10_R1C1", "R1C2", "Run_20_R1C3"]
     assert (rows, cols) == (1, 3)
-    
+
     # Check that indicies larger than 9 are handled appropriately.
     fov_names = ["R1C1", "R10C1", "R2C12"]
     expected_fovs, rows, cols = load_utils.get_tiled_fov_names(fov_names, return_dims=True)
-    
-    assert ns.natsorted([f"R{n}C{m}" for n in range(1,11) for m in range(1,13)]) == expected_fovs
-    
+
+    assert ns.natsorted([f"R{n}C{m}" for n in range(1, 11) for m in range(1, 13)]) == expected_fovs
+
     assert (rows, cols) == (10, 12)
 
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #23. Allows the stitching of tiled images $RnCm$, where $n,m>=10$.

**How did you implement your changes**

Adjusted the regex pattern matching and added an associate test.
**Remaining issues**

None ATM.