### PR TITLE
Clarify error message for empty directories in `load_imgs_from_dir`

### DIFF
--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -160,9 +160,7 @@ def load_imgs_from_tree(
         channels = [chan for _, chan in sorted(zip(channels_indices, all_channels))]
 
     if len(channels) == 0:
-        raise ValueError(
-            f"No images found in designated folder, {os.path.join(data_dir, fovs[0])}"
-        )
+        raise ValueError(f"No images found in designated folder, {os.path.join(data_dir, fovs[0])}")
 
     test_img = io.imread(os.path.join(data_dir, fovs[0], img_sub_folder, channels[0]))
 

--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -160,7 +160,9 @@ def load_imgs_from_tree(
         channels = [chan for _, chan in sorted(zip(channels_indices, all_channels))]
 
     if len(channels) == 0:
-        raise ValueError("No images found in designated folder")
+        raise ValueError(
+            f"No images found in designated folder, {os.path.join(data_dir, fovs[0])}"
+        )
 
     test_img = io.imread(os.path.join(data_dir, fovs[0], img_sub_folder, channels[0]))
 


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes angelolab/ark-analysis#971. Clarifies the error message if no channels found in a directory when `load_imgs_from_dir` is called. This is an issue that has happened with some users when `generate_cell_table` is called, which calls `load_imgs_from_dir`.

**How did you implement your changes**

Update the error message to include the name of the directory being loaded. While only the first FOV in the list gets this verification, this function most frequently receives a list with a single FOV anyways.