### PR TITLE
Tiled loading bug

### DIFF
--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -452,7 +452,7 @@ def load_tiled_img_data(
 
     # missing fov directories, read in a test image to get data type
     if single_dir:
-        test_path = os.path.join(data_dir, expected_fovs[0] + "_" + channel + "." + file_ext)
+        test_path = os.path.join(data_dir, fov_list[0] + "_" + channel + "." + file_ext)
     else:
         test_path = os.path.join(
             os.path.join(data_dir, fov_list[0], img_sub_folder, channel + "." + file_ext)

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -512,7 +512,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
             single_dir=single_dir,
         )
         # remove images and expected data for one fov
-        data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
+        data_xr[0, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
             os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:
@@ -558,8 +558,8 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
 
                     # remove images and expected data for one fov
                     data_xr[0, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
-                    shutil.rmtree(os.path.join(temp_dir2, "fov-4"))
-                    toffy_fovs.pop(list(toffy_fovs.keys())[2])
+                    shutil.rmtree(os.path.join(temp_dir2, "fov-3"))
+                    toffy_fovs.pop(list(toffy_fovs.keys())[0])
 
                     # check successful loading for one channel
                     loaded_xr = load_utils.load_tiled_img_data(

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -557,7 +557,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
                     data_xr["fovs"] = list(toffy_fovs.keys())
 
                     # remove images and expected data for one fov
-                    data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
+                    data_xr[0, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
                     shutil.rmtree(os.path.join(temp_dir2, "fov-4"))
                     toffy_fovs.pop(list(toffy_fovs.keys())[2])
 
@@ -589,7 +589,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
             single_dir=single_dir,
         )
         # remove images and expected data for one fov
-        data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
+        data_xr[0, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
             os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:
@@ -620,7 +620,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
             single_dir=single_dir,
         )
         # remove images and expected data for one fov
-        data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
+        data_xr[0, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
             os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -514,14 +514,14 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         # remove images and expected data for one fov
         data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
-            os.remove(os.path.join(temp_dir, "R2C1_chan1.tiff"))
+            os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:
-            shutil.rmtree(os.path.join(temp_dir, "R2C1"))
+            shutil.rmtree(os.path.join(temp_dir, "R1C1"))
 
         # check successful loading for one channel
         loaded_xr = load_utils.load_tiled_img_data(
             temp_dir,
-            ["R1C1", "R1C2", "R2C2"],
+            ["R1C2", "R2C1", "R2C2"],
             fovs,
             "chan1",
             single_dir=single_dir,
@@ -591,13 +591,13 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         # remove images and expected data for one fov
         data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
-            os.remove(os.path.join(temp_dir, "R2C1_chan1.tiff"))
+            os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:
-            shutil.rmtree(os.path.join(temp_dir, "R2C1"))
+            shutil.rmtree(os.path.join(temp_dir, "R1C1"))
 
         loaded_xr = load_utils.load_tiled_img_data(
             temp_dir,
-            ["R1C1", "R1C2", "R2C2"],
+            ["R1C2", "R2C1", "R2C2"],
             fovs,
             "chan1",
             single_dir=single_dir,
@@ -608,7 +608,7 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
 
     # test loading with run name prepend
     with tempfile.TemporaryDirectory() as temp_dir:
-        fovs = ["run_1_R1C1", "run_1_R1C2", "R2C1", "run_2_R2C2"]
+        fovs = ["R1C1", "run_1_R1C2", "run_1_R2C1", "run_2_R2C2"]
         filelocs, data_xr = test_utils.create_paired_xarray_fovs(
             temp_dir,
             fovs,
@@ -622,13 +622,13 @@ def test_load_tiled_img_data(single_dir, img_sub_folder):
         # remove images and expected data for one fov
         data_xr[2, :, :, :] = np.zeros((10, 10, 1), dtype="int16")
         if single_dir:
-            os.remove(os.path.join(temp_dir, "R2C1_chan1.tiff"))
+            os.remove(os.path.join(temp_dir, "R1C1_chan1.tiff"))
         else:
-            shutil.rmtree(os.path.join(temp_dir, "R2C1"))
+            shutil.rmtree(os.path.join(temp_dir, "R1C1"))
 
         loaded_xr = load_utils.load_tiled_img_data(
             temp_dir,
-            ["run_1_R1C1", "run_1_R1C2", "run_2_R2C2"],
+            ["run_1_R1C2", "run_1_R2C1", "run_2_R2C2"],
             fovs,
             "chan1",
             single_dir=single_dir,


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #33.

**How did you implement your changes**

Read in `fov_list[0]` image and not `expected_fov[0]`, since it is not guaranteed that R1C1 will be an actual image that was processed. Update the testing to try stitching when R1C1 is missing. 

**Remaining issues**

Bump this to both ark (before the new release) and toffy.
