### PR TITLE
Prevent image rotation during OME tiff conversion

### DIFF
--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -535,7 +535,7 @@ def fov_to_ome(
     )
 
     # convert to numpy for axes swapping without image rotation
-    fov_np = fov_xr.as_numpy()
+    fov_np = fov_xr.to_numpy()
     fov_np = np.swapaxes(fov_np, 2, 3)
     fov_np = np.swapaxes(fov_np, 1, 2)
 

--- a/src/alpineer/load_utils.py
+++ b/src/alpineer/load_utils.py
@@ -532,22 +532,11 @@ def fov_to_ome(
     # Reorder the DataArray as OME-TIFFs require [Channel, Y, X]
     fov_xr: xr.DataArray = load_imgs_from_tree(
         data_dir=data_dir, img_sub_folder=img_sub_folder, fovs=fovs, channels=channels
-    )
-
-    # convert to numpy for axes swapping without image rotation
-    fov_np = fov_xr.to_numpy()
-    fov_np = np.swapaxes(fov_np, 2, 3)
-    fov_np = np.swapaxes(fov_np, 1, 2)
-
-    fov_xr_reordered = xr.DataArray(
-        fov_np,
-        coords=[fov_xr.fovs, fov_xr.channels, fov_xr.rows, fov_xr.cols],
-        dims=["fovs", "channels", "rows", "cols"],
-    )
+    ).transpose("fovs", "channels", "rows", "cols")
 
     _compression: dict = {"algorithm": "zlib", "args": {"level": 6}}
 
-    for fov in fov_xr_reordered:
+    for fov in fov_xr:
         fov_name: str = fov.fovs.values
         ome_file_path: pathlib.Path = pathlib.Path(ome_save_dir) / f"{fov_name}.ome.tiff"
 

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -665,15 +665,7 @@ def create_img_data(tmp_path_factory) -> Iterator[Tuple[pathlib.Path, xr.DataArr
 
     # Create OME-TIFFs
     _compression: dict = {"algorithm": "zlib", "args": {"level": 6}}
-    data_np = data_xr.to_numpy()
-    data_np = np.swapaxes(data_np, 2, 3)
-    data_np = np.swapaxes(data_np, 1, 2)
-
-    data_xr_transposed = xr.DataArray(
-        data_np,
-        coords=[data_xr.fovs, data_xr.channels, data_xr.rows, data_xr.cols],
-        dims=["fovs", "channels", "rows", "cols"],
-    )
+    data_xr_transposed = data_xr.transpose("fovs", "channels", "rows", "cols")
 
     for fov in data_xr_transposed:
         fov_name: str = fov.fovs.values

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -665,7 +665,7 @@ def create_img_data(tmp_path_factory) -> Iterator[Tuple[pathlib.Path, xr.DataArr
 
     # Create OME-TIFFs
     _compression: dict = {"algorithm": "zlib", "args": {"level": 6}}
-    data_np = data_xr.as_numpy()
+    data_np = data_xr.to_numpy()
     data_np = np.swapaxes(data_np, 2, 3)
     data_np = np.swapaxes(data_np, 1, 2)
 

--- a/tests/load_utils_test.py
+++ b/tests/load_utils_test.py
@@ -665,7 +665,16 @@ def create_img_data(tmp_path_factory) -> Iterator[Tuple[pathlib.Path, xr.DataArr
 
     # Create OME-TIFFs
     _compression: dict = {"algorithm": "zlib", "args": {"level": 6}}
-    data_xr_transposed = data_xr.transpose("fovs", "channels", "cols", "rows")
+    data_np = data_xr.as_numpy()
+    data_np = np.swapaxes(data_np, 2, 3)
+    data_np = np.swapaxes(data_np, 1, 2)
+
+    data_xr_transposed = xr.DataArray(
+        data_np,
+        coords=[data_xr.fovs, data_xr.channels, data_xr.rows, data_xr.cols],
+        dims=["fovs", "channels", "rows", "cols"],
+    )
+
     for fov in data_xr_transposed:
         fov_name: str = fov.fovs.values
         ome_file_path: pathlib.Path = pathlib.Path(test_dir) / f"{fov_name}.ome.tiff"
@@ -726,7 +735,7 @@ class TestOMEConversion:
 
                 # Assert that the channel values in the OME-TIFF are correct.
                 for page, chan in zip(ome_tiff.pages, channels):
-                    actual_data = page.asarray().transpose()
+                    actual_data = page.asarray()
                     desired_data = self.data_xr.sel(fovs=fov_name, channels=chan).values
                     np.testing.assert_equal(actual_data, desired_data)
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #35. Keeps images from rotating during OME tiff conversion.

**How did you implement your changes**
 
The coordinates for the image data should be fovs, channels, rows, cols; currently cols and rows are switched.

**Remaining issues**

New release of alpineer and bump version in ark.
